### PR TITLE
Fix build error caused by upstream xtensor change (in xtensor master)

### DIFF
--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -450,7 +450,18 @@ namespace xt
     template <class D>
     inline bool pycontainer<D>::is_contiguous() const noexcept
     {
-        return layout_type::dynamic != layout();
+        if (PyArray_CHKFLAGS(python_array(), NPY_ARRAY_C_CONTIGUOUS))
+        {
+            return 1 == this->strides().back();
+        }
+        else if (PyArray_CHKFLAGS(python_array(), NPY_ARRAY_F_CONTIGUOUS))
+        {
+            return 1 == this->strides().front();
+        }
+        else
+        {
+            return false;
+        }
     }
 
     /**

--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -93,6 +93,7 @@ namespace xt
         void reshape(S&& shape, layout_type layout = base_type::static_layout);
 
         layout_type layout() const;
+        bool is_contiguous() const noexcept;
 
         using base_type::operator();
         using base_type::operator[];
@@ -440,6 +441,16 @@ namespace xt
         {
             return layout_type::dynamic;
         }
+    }
+
+    /**
+     * Return whether or not the container uses contiguous buffer
+     * @return Boolean for contiguous buffer
+     */
+    template <class D>
+    inline bool pycontainer<D>::is_contiguous() const noexcept
+    {
+        return layout_type::dynamic != layout();
     }
 
     /**


### PR DESCRIPTION
The upstream change broke the build: https://github.com/QuantStack/xtensor/commit/da7de15be73c396bc9ffb31fe8c630938c57ffe8

Add pycontainer::is_contiguous to make xtensor happy.