### PR TITLE
Document build, tests and fix CMakeLists.txt in benchmark.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -6,6 +6,13 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    project(xtensor-python-benchmark)
+
+    find_package(xtensor-python REQUIRED CONFIG)
+    set(XTENSOR_PYTHON_INCLUDE_DIR ${xtensor-python_INCLUDE_DIRS})
+endif ()
+
 message(STATUS "Forcing tests build type to Release")
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 
@@ -72,7 +79,7 @@ if (APPLE)
 elseif (MSVC)
     target_link_libraries(${XTENSOR_PYTHON_BENCHMARK_TARGET} ${PYTHON_LIBRARIES})
 else ()
-    target_link_libraries(${XTENSOR_PYTHON_BENCHMARK_TARGET} "-shared")
+    target_link_libraries(${XTENSOR_PYTHON_BENCHMARK_TARGET} PRIVATE xtensor-python)
 endif()
 
 configure_file(benchmark_pyarray.py benchmark_pyarray.py COPYONLY)
@@ -81,5 +88,11 @@ configure_file(benchmark_pybind_array.py benchmark_pybind_array.py COPYONLY)
 configure_file(benchmark_pyvectorize.py benchmark_pyvectorize.py COPYONLY)
 configure_file(benchmark_pybind_vectorize.py benchmark_pybind_vectorize.py COPYONLY)
 
-add_custom_target(xbenchmark DEPENDS ${XTENSOR_PYTHON_BENCHMARK_TARGET})
+add_custom_target(xbenchmark
+        COMMAND "${PYTHON_EXECUTABLE}" "benchmark_pyarray.py"
+        COMMAND "${PYTHON_EXECUTABLE}" "benchmark_pytensor.py"
+        COMMAND "${PYTHON_EXECUTABLE}" "benchmark_pybind_array.py"
+        COMMAND "${PYTHON_EXECUTABLE}" "benchmark_pyvectorize.py"
+        COMMAND "${PYTHON_EXECUTABLE}" "benchmark_pybind_vectorize.py"
+        DEPENDS ${XTENSOR_PYTHON_BENCHMARK_TARGET})
 

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -17,7 +17,6 @@ PYBIND11_MODULE(benchmark_xtensor_python, m)
     if(_import_array() < 0)
     {
         PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import");
-        return nullptr;
     }
 
     m.doc() = "Benchmark module for xtensor python bindings";

--- a/benchmark/setup.py
+++ b/benchmark/setup.py
@@ -107,7 +107,7 @@ setup(
     description='An example project using xtensor-python',
     long_description='',
     ext_modules=ext_modules,
-    install_requires=['pybind11==2.0.1'],
+    install_requires=['pybind11>=2.0.1'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
 )

--- a/benchmark/setup.py
+++ b/benchmark/setup.py
@@ -107,7 +107,7 @@ setup(
     description='An example project using xtensor-python',
     long_description='',
     ext_modules=ext_modules,
-    install_requires=['pybind11>=2.0.1'],
+    install_requires=['pybind11>=2.2.1'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
 )

--- a/docs/source/dev_build_options.rst
+++ b/docs/source/dev_build_options.rst
@@ -1,0 +1,45 @@
+.. Copyright (c) 2016, Johan Mabille and Sylvain Corlay
+
+   Distributed under the terms of the BSD 3-Clause License.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+
+Build, test and benchmark
+=========================
+
+``xtensor-python`` build supports the following options:
+
+- ``BUILD_TESTS``: enables the ``xtest`` and ``xbenchmark`` targets (see below).
+- ``DOWNLOAD_GTEST``: downloads ``gtest`` and builds it locally instead of using a binary installation.
+- ``GTEST_SRC_DIR``: indicates where to find the ``gtest`` sources instead of downloading them.
+
+All these options are disabled by default. Enabling ``DOWNLOAD_GTEST`` or
+setting ``GTEST_SRC_DIR`` enables ``BUILD_TESTS``.
+
+If the ``BUILD_TESTS`` option is enabled, the following targets are available:
+
+- xtest: builds an run the test suite.
+- xbenchmark: builds and runs the benchmarks.
+
+For instance, building the test suite of ``xtensor-python`` and downloading ``gtest`` automatically:
+
+.. code::
+
+    mkdir build
+    cd build
+    cmake -DDOWNLOAD_GTEST=ON ../
+    make xtest
+
+To run the benchmark:
+
+.. code::
+
+    make xbenchmark
+
+To test the Python bindings:
+
+.. code::
+
+    cd ..
+    pytest -s

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
 .. toctree::
    :caption: DEVELOPER ZONE
 
+   dev_build_options
    compilers
    releasing
 


### PR DESCRIPTION
Following the issue #204 I raised some while ago, I made the documentation and "fixed" the `CMakeLists.txt` in benchmark. This fix works for me with anaconda on Ubuntu16.04.