### PR TITLE
Update CMakeLists to correctly find pybind11 alias targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ else()
 endif()
     
 # Currently no required version for pybind11
-if(TARGET pybind11)
+if(TARGET pybind11 OR TARGET pybind11::headers)
     # pybind11 has a variable that indicates its version already, so use that
     message(STATUS "Found pybind11 v${pybind11_VERSION}")
 else()


### PR DESCRIPTION
When building xtensor-python and pybind11 as cmake submodule projects, the pybind aliased targets are not discovered correctly.

This PR adds an additional check to also look for the `pybind11:headers` aliased target and set the values accordingly.