### PR TITLE
Casters for strided_views, array_adaptor, and tensor_adaptor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,16 @@ message(STATUS "Found numpy: ${NUMPY_INCLUDE_DIRS}")
 # =====
 
 set(XTENSOR_PYTHON_HEADERS
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pyarray.hpp
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pyarray_backstrides.hpp
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pycontainer.hpp
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pystrides_adaptor.hpp
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pytensor.hpp
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pyvectorize.hpp
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/xtensor_python_config.hpp
-    ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/xtensor_type_caster_base.hpp
-)
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pyarray.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pyarray_backstrides.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pycontainer.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pynative_casters.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pystrides_adaptor.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pytensor.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/pyvectorize.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/xtensor_python_config.hpp
+        ${XTENSOR_PYTHON_INCLUDE_DIR}/xtensor-python/xtensor_type_caster_base.hpp
+        )
 
 add_library(xtensor-python INTERFACE)
 target_include_directories(xtensor-python INTERFACE

--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -21,6 +21,7 @@
 #include "pyarray_backstrides.hpp"
 #include "pycontainer.hpp"
 #include "pystrides_adaptor.hpp"
+#include "pynative_casters.hpp"
 #include "xtensor_type_caster_base.hpp"
 
 namespace xt
@@ -91,11 +92,6 @@ namespace pybind11
             }
         };
 
-        // Type caster for casting xarray to ndarray
-        template <class T, xt::layout_type L>
-        struct type_caster<xt::xarray<T, L>> : xtensor_type_caster_base<xt::xarray<T, L>>
-        {
-        };
     }
 }
 

--- a/include/xtensor-python/pynative_casters.hpp
+++ b/include/xtensor-python/pynative_casters.hpp
@@ -1,0 +1,52 @@
+/***************************************************************************
+* Copyright (c) Wolf Vollprecht, Johan Mabille and Sylvain Corlay          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef PYNATIVE_CASTERS_HPP
+#define PYNATIVE_CASTERS_HPP
+
+#include "xtensor_type_caster_base.hpp"
+
+
+namespace pybind11
+{
+    namespace detail
+    {
+        // Type caster for casting xarray to ndarray
+        template <class T, xt::layout_type L>
+        struct type_caster<xt::xarray<T, L>> : xtensor_type_caster_base<xt::xarray<T, L>>
+        {
+        };
+
+        // Type caster for casting xt::xtensor to ndarray
+        template <class T, std::size_t N, xt::layout_type L>
+        struct type_caster<xt::xtensor<T, N, L>> : xtensor_type_caster_base<xt::xtensor<T, N, L>>
+        {
+        };
+
+        // Type caster for casting xt::xstrided_view to ndarray
+        template <class CT, class S, xt::layout_type L, class FST>
+        struct type_caster<xt::xstrided_view<CT, S, L, FST>> : xtensor_type_caster_base<xt::xstrided_view<CT, S, L, FST>>
+        {
+        };
+
+        // Type caster for casting xt::xarray_adaptor to ndarray
+        template <class EC, xt::layout_type L, class SC, class Tag>
+        struct type_caster<xt::xarray_adaptor<EC, L, SC, Tag>> : xtensor_type_caster_base<xt::xarray_adaptor<EC, L, SC, Tag>>
+        {
+        };
+
+        // Type caster for casting xt::xtensor_adaptor to ndarray
+        template <class EC, std::size_t N, xt::layout_type L, class Tag>
+        struct type_caster<xt::xtensor_adaptor<EC, N, L, Tag>> : xtensor_type_caster_base<xt::xtensor_adaptor<EC, N, L, Tag>>
+        {
+        };
+    }
+}
+
+#endif

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -21,6 +21,7 @@
 
 #include "pycontainer.hpp"
 #include "pystrides_adaptor.hpp"
+#include "pynative_casters.hpp"
 #include "xtensor_type_caster_base.hpp"
 
 namespace xt
@@ -99,11 +100,6 @@ namespace pybind11
             }
         };
 
-        // Type caster for casting xt::xtensor to ndarray
-        template <class T, std::size_t N, xt::layout_type L>
-        struct type_caster<xt::xtensor<T, N, L>> : xtensor_type_caster_base<xt::xtensor<T, N, L>>
-        {
-        };
     }
 }
 

--- a/include/xtensor-python/xtensor_type_caster_base.hpp
+++ b/include/xtensor-python/xtensor_type_caster_base.hpp
@@ -23,7 +23,7 @@ namespace pybind11
 {
     namespace detail
     {
-        // Casts an xtensor (or xarray) type to numpy array.If given a base,
+        // Casts a strided expression type to numpy array.If given a base,
         // the numpy array references the src data, otherwise it'll make a copy.
         // The writeable attributes lets you specify writeable flag for the array.
         template <typename Type>
@@ -39,7 +39,7 @@ namespace pybind11
             std::vector<std::size_t> python_shape(src.shape().size());
             std::copy(src.shape().begin(), src.shape().end(), python_shape.begin());
 
-            array a(python_shape, python_strides, src.begin(), base);
+            array a(python_shape, python_strides, &*(src.begin()), base);
 
             if (!writeable)
             {
@@ -49,8 +49,8 @@ namespace pybind11
             return a.release();
         }
 
-        // Takes an lvalue ref to some xtensor (or xarray) type and a (python) base object, creating a numpy array that
-        // reference the xtensor object's data with `base` as the python-registered base class (if omitted,
+        // Takes an lvalue ref to some strided expression type and a (python) base object, creating a numpy array that
+        // reference the expression object's data with `base` as the python-registered base class (if omitted,
         // the base will be set to None, and lifetime management is up to the caller).  The numpy array is
         // non-writeable if the given type is const.
         template <typename Type, typename CType>
@@ -59,7 +59,7 @@ namespace pybind11
             return xtensor_array_cast<Type>(src, parent, !std::is_const<CType>::value);
         }
 
-        // Takes a pointer to xtensor (or xarray), builds a capsule around it, then returns a numpy
+        // Takes a pointer to a strided expression, builds a capsule around it, then returns a numpy
         // array that references the encapsulated data with a python-side reference to the capsule to tie
         // its destruction to that of any dependent python objects.  Const-ness is determined by whether or
         // not the CType of the pointer given is const.
@@ -70,7 +70,7 @@ namespace pybind11
             return xtensor_ref_array<Type>(*src, base);
         }
 
-        // Base class of type_caster for xtensor and xarray
+        // Base class of type_caster for strided expressions
         template <class Type>
         struct xtensor_type_caster_base
         {

--- a/test_python/test_pyarray.py
+++ b/test_python/test_pyarray.py
@@ -166,6 +166,73 @@ class XtensorTest(TestCase):
             # FIXME: the TypeError information is not informative
             xt.diff_shape_overload(np.ones((2, 2, 2)))
 
+    def test_native_casters(self):
+        import gc
+
+        # check keep alive policy for get_strided_view()
+        gc.collect()
+        obj = xt.test_native_casters()
+        a = obj.get_strided_view()
+        obj = None
+        gc.collect()
+        _ = np.zeros((100, 100))
+        self.assertEqual(a.sum(), a.size)
+
+        # check keep alive policy for get_array_adapter()
+        gc.collect()
+        obj = xt.test_native_casters()
+        a = obj.get_array_adapter()
+        obj = None
+        gc.collect()
+        _ = np.zeros((100, 100))
+        self.assertEqual(a.sum(), a.size)
+
+        # check keep alive policy for get_array_adapter()
+        gc.collect()
+        obj = xt.test_native_casters()
+        a = obj.get_tensor_adapter()
+        obj = None
+        gc.collect()
+        _ = np.zeros((100, 100))
+        self.assertEqual(a.sum(), a.size)
+
+        # check keep alive policy for get_owning_array_adapter()
+        gc.collect()
+        obj = xt.test_native_casters()
+        a = obj.get_owning_array_adapter()
+        gc.collect()
+        _ = np.zeros((100, 100))
+        self.assertEqual(a.sum(), a.size)
+
+        # check keep alive policy for view_keep_alive_member_function()
+        gc.collect()
+        a = np.ones((100, 100))
+        b = obj.view_keep_alive_member_function(a)
+        obj = None
+        a = None
+        gc.collect()
+        _ = np.zeros((100, 100))
+        self.assertEqual(b.sum(), b.size)
+
+        # check shared buffer (insure that no copy is done)
+        obj = xt.test_native_casters()
+        arr = obj.get_array()
+
+        strided_view = obj.get_strided_view()
+        strided_view[0, 1] = -1
+        self.assertEqual(strided_view.shape, (1, 2))
+        self.assertEqual(arr[0, 2], -1)
+
+        adapter = obj.get_array_adapter()
+        self.assertEqual(adapter.shape, (2, 2))
+        adapter[1, 1] = -2
+        self.assertEqual(arr[0, 5], -2)
+
+        adapter = obj.get_tensor_adapter()
+        self.assertEqual(adapter.shape, (2, 2))
+        adapter[1, 1] = -3
+        self.assertEqual(arr[0, 5], -3)
+
 
 class AttributeTest(TestCase):
 


### PR DESCRIPTION
This PR partly solves #130 by adding pybind11 type casters for ```strided_views``` and ```array/tensor_adapters```.

As for ```xarrays``` and ```xtensors```, those objects are casted to ```ndarray``` and do not use any proxy object (such as ```pyarray``` or ```pytensor```): I did a bit of refactoring to put all those casters in a dedicated file. 

Memory management becomes of course trickier with such objects.  I have the impression that what is done in ```xtensor_type_caster_base``` to handle return value policies is generic enough to fit these cases but I am not totally sure. I tried to demonstrate critical cases in the test file (cpp main). The tests *validating* the correctness of the memory management (keep alive policies) are perhaps not very interesting for regression detection has they focus on pybind11 mechanism  rather than xtensor_python and could probably be removed.