### PR TITLE
fix pyarray column_major from xexpression

### DIFF
--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -443,7 +443,7 @@ namespace xt
         // TODO: prevent intermediary shape allocation
         shape_type shape = xtl::forward_sequence<shape_type, decltype(e.derived_cast().shape())>(e.derived_cast().shape());
         strides_type strides = xtl::make_sequence<strides_type>(shape.size(), size_type(0));
-        compute_strides(shape, layout_type::row_major, strides);
+        compute_strides(shape, L, strides);
         init_array(shape, strides);
         semantic_base::assign(e);
     }

--- a/test/test_pyarray.cpp
+++ b/test/test_pyarray.cpp
@@ -181,6 +181,18 @@ namespace xt
         EXPECT_EQ(c(0, 1), a1(0, 1) + a2(0, 1));
         EXPECT_EQ(c(1, 0), a1(1, 0) + a2(1, 0));
         EXPECT_EQ(c(1, 1), a1(1, 1) + a2(1, 1));
+
+        pyarray<int, xt::layout_type::row_major> d = a1 + a2;
+        EXPECT_EQ(d(0, 0), a1(0, 0) + a2(0, 0));
+        EXPECT_EQ(d(0, 1), a1(0, 1) + a2(0, 1));
+        EXPECT_EQ(d(1, 0), a1(1, 0) + a2(1, 0));
+        EXPECT_EQ(d(1, 1), a1(1, 1) + a2(1, 1));
+
+        pyarray<int, xt::layout_type::column_major> e = a1 + a2;
+        EXPECT_EQ(e(0, 0), a1(0, 0) + a2(0, 0));
+        EXPECT_EQ(e(0, 1), a1(0, 1) + a2(0, 1));
+        EXPECT_EQ(e(1, 0), a1(1, 0) + a2(1, 0));
+        EXPECT_EQ(e(1, 1), a1(1, 1) + a2(1, 1));
     }
 
     TEST(pyarray, resize)


### PR DESCRIPTION
Description
--

Fix `pyarray` constructor  from `xexpression` when using `xt::layout_type::column_major` as a class template argument.