### PR TITLE
`pyarray` initializers lists work with all layouts

### DIFF
--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -224,6 +224,8 @@ namespace xt
         storage_type& storage_impl() noexcept;
         const storage_type& storage_impl() const noexcept;
 
+        layout_type default_dynamic_layout();
+
         friend class xcontainer<pyarray<T, L>>;
         friend class pycontainer<pyarray<T, L>>;
     };
@@ -254,7 +256,7 @@ namespace xt
     inline pyarray<T, L>::pyarray(const value_type& t)
         : base_type()
     {
-        base_type::resize(xt::shape<shape_type>(t), layout_type::row_major);
+        base_type::resize(xt::shape<shape_type>(t), default_dynamic_layout());
         nested_copy(m_storage.begin(), t);
     }
 
@@ -262,40 +264,40 @@ namespace xt
     inline pyarray<T, L>::pyarray(nested_initializer_list_t<T, 1> t)
         : base_type()
     {
-        base_type::resize(xt::shape<shape_type>(t), layout_type::row_major);
-        nested_copy(m_storage.begin(), t);
+        base_type::resize(xt::shape<shape_type>(t), default_dynamic_layout());
+        L == layout_type::row_major ? nested_copy(m_storage.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     template <class T, layout_type L>
     inline pyarray<T, L>::pyarray(nested_initializer_list_t<T, 2> t)
         : base_type()
     {
-        base_type::resize(xt::shape<shape_type>(t), layout_type::row_major);
-        nested_copy(m_storage.begin(), t);
+        base_type::resize(xt::shape<shape_type>(t), default_dynamic_layout());
+        L == layout_type::row_major ? nested_copy(m_storage.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     template <class T, layout_type L>
     inline pyarray<T, L>::pyarray(nested_initializer_list_t<T, 3> t)
         : base_type()
     {
-        base_type::resize(xt::shape<shape_type>(t), layout_type::row_major);
-        nested_copy(m_storage.begin(), t);
+        base_type::resize(xt::shape<shape_type>(t), default_dynamic_layout());
+        L == layout_type::row_major ? nested_copy(m_storage.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     template <class T, layout_type L>
     inline pyarray<T, L>::pyarray(nested_initializer_list_t<T, 4> t)
         : base_type()
     {
-        base_type::resize(xt::shape<shape_type>(t), layout_type::row_major);
-        nested_copy(m_storage.begin(), t);
+        base_type::resize(xt::shape<shape_type>(t), default_dynamic_layout());
+        L == layout_type::row_major ? nested_copy(m_storage.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     template <class T, layout_type L>
     inline pyarray<T, L>::pyarray(nested_initializer_list_t<T, 5> t)
         : base_type()
     {
-        base_type::resize(xt::shape<shape_type>(t), layout_type::row_major);
-        nested_copy(m_storage.begin(), t);
+        base_type::resize(xt::shape<shape_type>(t), default_dynamic_layout());
+        L == layout_type::row_major ? nested_copy(m_storage.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     template <class T, layout_type L>
@@ -443,7 +445,9 @@ namespace xt
         // TODO: prevent intermediary shape allocation
         shape_type shape = xtl::forward_sequence<shape_type, decltype(e.derived_cast().shape())>(e.derived_cast().shape());
         strides_type strides = xtl::make_sequence<strides_type>(shape.size(), size_type(0));
-        compute_strides(shape, L, strides);
+        layout_type layout = default_dynamic_layout();
+
+        compute_strides(shape, layout, strides);
         init_array(shape, strides);
         semantic_base::assign(e);
     }
@@ -558,6 +562,12 @@ namespace xt
     inline auto pyarray<T, L>::storage_impl() const noexcept -> const storage_type&
     {
         return m_storage;
+    }
+
+    template <class T, layout_type L>
+    layout_type pyarray<T, L>::default_dynamic_layout()
+    {
+        return L == layout_type::dynamic ? layout_type::row_major : L;
     }
 }
 

--- a/test/test_pyarray.cpp
+++ b/test/test_pyarray.cpp
@@ -37,7 +37,7 @@ namespace xt
 
     TEST(pyarray, initializer_constructor)
     {
-        pyarray<int> t 
+        pyarray<int> r
           {{{ 0,  1,  2}, 
             { 3,  4,  5}, 
             { 6,  7,  8}}, 
@@ -45,9 +45,36 @@ namespace xt
             {12, 13, 14}, 
             {15, 16, 17}}}; 
 
-        EXPECT_EQ(t.dimension(), 3);
-        EXPECT_EQ(t(0, 0, 1), 1);
-        EXPECT_EQ(t.shape()[0], 2);
+        EXPECT_EQ(r.layout(), xt::layout_type::row_major);
+        EXPECT_EQ(r.dimension(), 3);
+        EXPECT_EQ(r(0, 0, 1), 1);
+        EXPECT_EQ(r.shape()[0], 2);
+
+        pyarray<int, xt::layout_type::column_major> c
+          {{{ 0,  1,  2}, 
+            { 3,  4,  5}, 
+            { 6,  7,  8}}, 
+           {{ 9, 10, 11}, 
+            {12, 13, 14}, 
+            {15, 16, 17}}}; 
+
+        EXPECT_EQ(c.layout(), xt::layout_type::column_major);
+        EXPECT_EQ(c.dimension(), 3);
+        EXPECT_EQ(c(0, 0, 1), 1);
+        EXPECT_EQ(c.shape()[0], 2);
+
+        pyarray<int, xt::layout_type::dynamic> d
+          {{{ 0,  1,  2}, 
+            { 3,  4,  5}, 
+            { 6,  7,  8}}, 
+           {{ 9, 10, 11}, 
+            {12, 13, 14}, 
+            {15, 16, 17}}}; 
+
+        EXPECT_EQ(d.layout(), xt::layout_type::row_major);
+        EXPECT_EQ(d.dimension(), 3);
+        EXPECT_EQ(d(0, 0, 1), 1);
+        EXPECT_EQ(d.shape()[0], 2);
     }
 
     TEST(pyarray, shaped_constructor)


### PR DESCRIPTION
Description
--
Make initializer lists work with all layouts. Change default dynamic layout to `layout_type::row_major`.