### PR TITLE
Fixing constructor bug pytensor<..., 0>

### DIFF
--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -107,14 +107,14 @@ namespace xt
 {
     namespace detail {
 
-        template <std::size_t N, typename = void>
+        template <std::size_t N>
         struct numpy_strides
         {
             npy_intp value[N];
         };
 
-        template <std::size_t N>
-        struct numpy_strides<N, typename std::enable_if_t<(N == 0)>::type>
+        template <>
+        struct numpy_strides<0>
         {
             npy_intp* value = nullptr;
         };

--- a/test/test_pytensor.cpp
+++ b/test/test_pytensor.cpp
@@ -65,6 +65,15 @@ namespace xt
         EXPECT_THROW(pyt3::from_shape(shp), std::runtime_error);
     }
 
+    TEST(pytensor, scalar_from_shape)
+    {
+        std::array<size_t, 0> shape;
+        auto a = pytensor<double, 0>::from_shape(shape);
+        pytensor<double, 0> b(1.2);
+        EXPECT_TRUE(a.size() == b.size());
+        EXPECT_TRUE(xt::has_shape(a, b.shape()));
+    }
+
     TEST(pytensor, strided_constructor)
     {
         central_major_result<container_type> cmr;

--- a/test_python/main.cpp
+++ b/test_python/main.cpp
@@ -227,6 +227,11 @@ void col_major_array(xt::pyarray<double, xt::layout_type::column_major>& arg)
     }
 }
 
+xt::pytensor<int, 0> xscalar(const xt::pytensor<int, 1>& arg)
+{
+    return xt::sum(arg);
+}
+
 template <class T>
 using ndarray = xt::pyarray<T, xt::layout_type::row_major>;
 
@@ -284,6 +289,8 @@ PYBIND11_MODULE(xtensor_python_test, m)
 
     m.def("col_major_array", col_major_array);
     m.def("row_major_tensor", row_major_tensor);
+
+    m.def("xscalar", xscalar);
 
     py::class_<C>(m, "C")
         .def(py::init<>())

--- a/test_python/test_pyarray.py
+++ b/test_python/test_pyarray.py
@@ -151,6 +151,10 @@ class XtensorTest(TestCase):
         xt.col_major_array(varF)
         xt.col_major_array(varF[:, :, 0]) # still col major!
 
+    def test_xscalar(self):
+        var = np.arange(50, dtype=int)
+        self.assertTrue(np.sum(var) == xt.xscalar(var))
+
     def test_bad_argument_call(self):
         with self.assertRaises(TypeError):
             xt.simple_array("foo")


### PR DESCRIPTION
Fix of the following:

I am using a library that uses 'xscalar'. Now I'm wrapping with xtensor-python and am getting on Windows only:
```
pytensor.hpp(436,18): error C2466: cannot allocate an array of constant size 0
...
message : see reference to function template instantiation 'xt::pytensor<double,0,xt::layout_type::dynamic> xt::pytensor<double,0,xt::layout_type::dynamic>::from_shape<std::array<size_t,0>>(S &&)' being compiled with
[
    S=std::array<size_t,0>
]
```
Ref: https://github.com/tdegeus/GMatTensor/pull/29