### PR TITLE
ignore unused parameter 'buf' warning

### DIFF
--- a/include/xtensor-python/xtensor_type_caster_base.hpp
+++ b/include/xtensor-python/xtensor_type_caster_base.hpp
@@ -107,9 +107,8 @@ namespace pybind11
         struct pybind_array_dim_checker
         {
             template <class B>
-            static bool run(const B& buf)
+            static bool run(const B&)
             {
-                (void)(buf);
                 return true;
             }
         };
@@ -139,9 +138,8 @@ namespace pybind11
         struct pybind_array_shape_checker
         {
             template <class B>
-            static bool run(const B& buf)
+            static bool run(const B&)
             {
-                (void)(buf);
                 return true;
             }
         };

--- a/include/xtensor-python/xtensor_type_caster_base.hpp
+++ b/include/xtensor-python/xtensor_type_caster_base.hpp
@@ -109,6 +109,7 @@ namespace pybind11
             template <class B>
             static bool run(const B& buf)
             {
+                (void)(buf);
                 return true;
             }
         };
@@ -140,6 +141,7 @@ namespace pybind11
             template <class B>
             static bool run(const B& buf)
             {
+                (void)(buf);
                 return true;
             }
         };

--- a/include/xtensor-python/xtensor_type_caster_base.hpp
+++ b/include/xtensor-python/xtensor_type_caster_base.hpp
@@ -107,7 +107,7 @@ namespace pybind11
         struct pybind_array_dim_checker
         {
             template <class B>
-            static bool run(const B&)
+            static bool run(const B& /*buf*/)
             {
                 return true;
             }
@@ -138,7 +138,7 @@ namespace pybind11
         struct pybind_array_shape_checker
         {
             template <class B>
-            static bool run(const B&)
+            static bool run(const B& /*buf*/)
             {
                 return true;
             }


### PR DESCRIPTION
I included <xtensor-python/xtensor_type_caster_base.hpp> into my code to let pybind11 automatically convert xtensor xarrays to numpy arrays.

 However I get two "-wunused-parameter warnings" which seem to be straightforward to fix :-)