### PR TITLE
only search for numpy when the numpy-include directory is not passed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ else()
     message(STATUS "Found pybind11: ${pybind11_INCLUDE_DIRS}/pybind11")
 endif()
 
-# if NUMPY_INCLUDE_DIRS is not set, then we try to find it
 if(NOT NUMPY_INCLUDE_DIRS)
     set(NUMPY_REQUIRED_VERSION 1.14.0)
     find_package(NumPy ${NUMPY_REQUIRED_VERSION} REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,12 @@ else()
     message(STATUS "Found pybind11: ${pybind11_INCLUDE_DIRS}/pybind11")
 endif()
 
-find_package(NumPy REQUIRED)
-message(STATUS "Found numpy: ${NUMPY_INCLUDE_DIRS}")
-
+# if NUMPY_INCLUDE_DIRS is not set, then we try to find it
+if(NOT NUMPY_INCLUDE_DIRS)
+    set(NUMPY_REQUIRED_VERSION 1.14.0)
+    find_package(NumPy ${NUMPY_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found numpy: ${NUMPY_INCLUDE_DIRS}")
+endif()
 # Build
 # =====
 


### PR DESCRIPTION
In the emscripten / wasm case we cannot call the default `find_package(NumPy ${NUMPY_REQUIRED_VERSION} REQUIRED)` since this tries to call a non-existing python executable for the `emscripten-wasm32` platform (we only have a python library for that platform).
Therefore we pass `NUMPY_INCLUDE_DIRS` explicitly when building for wasm.