### PR TITLE
Install as arch-independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ export(EXPORT ${PROJECT_NAME}-targets
 install(FILES ${XTENSOR_PYTHON_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor-python)
 
-set(XTENSOR_PYTHON_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE
+set(XTENSOR_PYTHON_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}" CACHE
     STRING "install path for xtensor-pythonConfig.cmake")
 
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in


### PR DESCRIPTION
xternsor-python is header only library, so prefer arch-independed paths cmake.

References:
 * https://github.com/xtensor-stack/xtl/commit/d877d94836aff4d0f727acf3eaab8f4880ecb625
 * https://github.com/xtensor-stack/xtensor/commit/7738389861044c9618c7d59fb7602f7dddc1df7f