### PR TITLE
xtensor-python needs to be updated to xtensor new structure

### DIFF
--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -14,9 +14,9 @@
 #include <cstddef>
 #include <vector>
 
-#include "xtensor/xbuffer_adaptor.hpp"
-#include "xtensor/xiterator.hpp"
-#include "xtensor/xsemantic.hpp"
+#include "xtensor/containers/xbuffer_adaptor.hpp"
+#include "xtensor/core/xiterator.hpp"
+#include "xtensor/core/xsemantic.hpp"
 
 #include "pyarray_backstrides.hpp"
 #include "pycontainer.hpp"

--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -32,7 +32,7 @@
 #undef copysign
 
 #include <cmath>
-#include "xtensor/xcontainer.hpp"
+#include "xtensor/containers/xcontainer.hpp"
 
 #include "xtl/xsequence.hpp"
 

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -14,10 +14,10 @@
 #include <array>
 #include <cstddef>
 
-#include "xtensor/xbuffer_adaptor.hpp"
-#include "xtensor/xiterator.hpp"
-#include "xtensor/xsemantic.hpp"
-#include "xtensor/xutils.hpp"
+#include "xtensor/containers/xbuffer_adaptor.hpp"
+#include "xtensor/core/xiterator.hpp"
+#include "xtensor/core/xsemantic.hpp"
+#include "xtensor/utils/xutils.hpp"
 
 #include "pycontainer.hpp"
 #include "pystrides_adaptor.hpp"

--- a/include/xtensor-python/pyvectorize.hpp
+++ b/include/xtensor-python/pyvectorize.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 
 #include "pyarray.hpp"
-#include "xtensor/xvectorize.hpp"
+#include "xtensor/core/xvectorize.hpp"
 
 namespace xt
 {

--- a/include/xtensor-python/xtensor_type_caster_base.hpp
+++ b/include/xtensor-python/xtensor_type_caster_base.hpp
@@ -14,8 +14,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xfixed.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/containers/xfixed.hpp"
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>

--- a/test_python/main.cpp
+++ b/test_python/main.cpp
@@ -16,8 +16,8 @@
 #include "xtensor-python/pyarray.hpp"
 #include "xtensor-python/pytensor.hpp"
 #include "xtensor-python/pyvectorize.hpp"
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xstrided_view.hpp"
+#include "xtensor/containers/xadapt.hpp"
+#include "xtensor/views/xstrided_view.hpp"
 
 namespace py = pybind11;
 using complex_t = std::complex<double>;


### PR DESCRIPTION
The imports of the latest version of xtensor have changed, and should be changed in xtensor-python. 